### PR TITLE
#0.1 feat(database): add initial database schema migration 

### DIFF
--- a/supabase/migrations/20260301000000_initial_schema.sql
+++ b/supabase/migrations/20260301000000_initial_schema.sql
@@ -1,0 +1,208 @@
+-- Initial Schema Migration
+-- Tüm tabloları, index'leri, trigger'ları ve RLS ayarlarını içerir.
+
+-- =============================================================================
+-- 1. public.users (auth.users ile senkronize)
+-- =============================================================================
+CREATE TABLE public.users (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  full_name TEXT,
+  avatar_url TEXT,
+  currency TEXT NOT NULL DEFAULT 'TRY',
+  language TEXT NOT NULL DEFAULT 'tr',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 2. public.categories
+-- =============================================================================
+CREATE TABLE public.categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('income', 'expense')),
+  icon TEXT NOT NULL,
+  color TEXT NOT NULL,
+  bg_color TEXT NOT NULL,
+  is_system BOOLEAN NOT NULL DEFAULT false,
+  user_id UUID REFERENCES public.users(id) ON DELETE CASCADE,
+  parent_id UUID REFERENCES public.categories(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT chk_system_no_user CHECK (
+    (is_system = true AND user_id IS NULL) OR (is_system = false AND user_id IS NOT NULL)
+  )
+);
+
+-- =============================================================================
+-- 3. public.transactions
+-- =============================================================================
+CREATE TABLE public.transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  category_id UUID NOT NULL REFERENCES public.categories(id) ON DELETE RESTRICT,
+  title TEXT,
+  amount NUMERIC(12,2) NOT NULL CHECK (amount > 0),
+  type TEXT NOT NULL CHECK (type IN ('income', 'expense')),
+  date DATE NOT NULL DEFAULT CURRENT_DATE,
+  note TEXT,
+  receipt_url TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 4. public.recurring_transactions
+-- =============================================================================
+CREATE TABLE public.recurring_transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  category_id UUID NOT NULL REFERENCES public.categories(id) ON DELETE RESTRICT,
+  title TEXT NOT NULL,
+  amount NUMERIC(12,2) NOT NULL CHECK (amount > 0),
+  type TEXT NOT NULL CHECK (type IN ('income', 'expense')),
+  frequency TEXT NOT NULL CHECK (frequency IN ('daily', 'weekly', 'monthly', 'yearly')),
+  start_date DATE NOT NULL,
+  next_date DATE NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 5. public.budgets
+-- =============================================================================
+CREATE TABLE public.budgets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  category_id UUID NOT NULL REFERENCES public.categories(id) ON DELETE CASCADE,
+  limit_amount NUMERIC(12,2) NOT NULL CHECK (limit_amount > 0),
+  period TEXT NOT NULL DEFAULT 'monthly' CHECK (period IN ('weekly', 'monthly', 'yearly')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, category_id, period)
+);
+
+-- =============================================================================
+-- 6. public.goals
+-- =============================================================================
+CREATE TABLE public.goals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  target_amount NUMERIC(12,2) NOT NULL CHECK (target_amount > 0),
+  saved_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (saved_amount >= 0),
+  target_date DATE,
+  color TEXT NOT NULL DEFAULT '#6366F1',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 7. public.goal_contributions
+-- =============================================================================
+CREATE TABLE public.goal_contributions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  goal_id UUID NOT NULL REFERENCES public.goals(id) ON DELETE CASCADE,
+  amount NUMERIC(12,2) NOT NULL CHECK (amount > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 8. public.user_preferences
+-- =============================================================================
+CREATE TABLE public.user_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID UNIQUE NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  daily_reminder_enabled BOOLEAN NOT NULL DEFAULT true,
+  reminder_time TIME NOT NULL DEFAULT '20:00',
+  dark_mode BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 9. public.ai_conversations
+-- =============================================================================
+CREATE TABLE public.ai_conversations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  title TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- 10. public.ai_messages
+-- =============================================================================
+CREATE TABLE public.ai_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL REFERENCES public.ai_conversations(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- Indexes
+-- =============================================================================
+CREATE INDEX idx_transactions_user_id ON public.transactions(user_id);
+CREATE INDEX idx_transactions_date ON public.transactions(date DESC);
+CREATE INDEX idx_transactions_category_id ON public.transactions(category_id);
+CREATE INDEX idx_recurring_user_id ON public.recurring_transactions(user_id);
+CREATE INDEX idx_budgets_user_id ON public.budgets(user_id);
+CREATE INDEX idx_goals_user_id ON public.goals(user_id);
+CREATE INDEX idx_categories_user_id ON public.categories(user_id);
+CREATE INDEX idx_categories_parent_id ON public.categories(parent_id);
+CREATE INDEX idx_ai_messages_conversation_id ON public.ai_messages(conversation_id);
+
+-- =============================================================================
+-- Updated_at trigger function
+-- =============================================================================
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- Apply updated_at triggers
+-- =============================================================================
+CREATE TRIGGER trg_users_updated_at
+  BEFORE UPDATE ON public.users
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_transactions_updated_at
+  BEFORE UPDATE ON public.transactions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_recurring_transactions_updated_at
+  BEFORE UPDATE ON public.recurring_transactions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_budgets_updated_at
+  BEFORE UPDATE ON public.budgets
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_goals_updated_at
+  BEFORE UPDATE ON public.goals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_user_preferences_updated_at
+  BEFORE UPDATE ON public.user_preferences
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================================================
+-- RLS (Row Level Security) - Her tablo icin etkinlestir
+-- =============================================================================
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.transactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.recurring_transactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.budgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.goals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.goal_contributions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ai_conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ai_messages ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Supabase initial migration dosyası oluşturuldu (`20260301000000_initial_schema.sql`)
- 10 tablo: users, categories, transactions, recurring_transactions, budgets, goals, goal_contributions, user_preferences, ai_conversations, ai_messages
- Tüm CHECK, UNIQUE, FOREIGN KEY constraint'leri, 9 index, 6 updated_at trigger ve 10 tablo için RLS tanımları dahil

## Test plan
- [ ] `pnpm db:reset` ile migration hatasız çalışmalı
- [ ] Tüm tabloların oluştuğu doğrulanmalı
- [ ] RLS'in aktif olduğu kontrol edilmeli

REF: #0.1